### PR TITLE
fix: .editorconfig max_line_length value

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,4 +7,4 @@ charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
 end_of_line = lf
-max_line_length = null
+max_line_length = off


### PR DESCRIPTION
Fixes editor warnings as null is not a valid value for max_line_length